### PR TITLE
Fix deprecation warning in search template

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     version='1.3.0.dev0',
 
     install_requires=[
-        'sphinx_rtd_theme',
+        'sphinx_rtd_theme >= 0.5.0.dev0',
         'setuptools',
     ],
 

--- a/src/sphinx_zon_theme/search.html
+++ b/src/sphinx_zon_theme/search.html
@@ -1,22 +1,14 @@
 {%- extends "sphinx_rtd_theme/search.html" %}
-{% if theme_elasticsearch_host %}
-{% set script_files = script_files + ['_static/elasticsearch.jquery.min.js'] %}
-{% endif %}
 
-{% block footer %}
-  {%- if theme_elasticsearch_host %}
-  {# Cannot use `script_files` for this, since we need to come *after*
-     `searchtools.js` included by the upstream `search.html` to monkeypatch it.
-     However, due to `extends`, that runs after us, so instead we take advantage
-     that block `footer` comes after `script_files` in `layout.html`. #}
-  <script type="text/javascript" src="{{ pathto('_static/search-elastic.js', 1) }}"></script>
-
-  <script type="text/javascript">
-    DOCUMENTATION_OPTIONS.ELASTICSEARCH_HOST = "{{theme_elasticsearch_host}}";
-    DOCUMENTATION_OPTIONS.ELASTICSEARCH_INDEX = "{{theme_elasticsearch_index}}";
-    DOCUMENTATION_OPTIONS.PUBLIC_URL_ROOT = "{{theme_public_url_root}}";
-  </script>
-  {%- endif %}
-
+{% block scripts %}
   {{ super() }}
+  {% if theme_elasticsearch_host %}
+    <script src="{{ pathto('_static/elasticsearch.jquery.min.js', 1) }}"></script>
+    <script src="{{ pathto('_static/search-elastic.js', 1) }}"></script>
+    <script>
+      DOCUMENTATION_OPTIONS.ELASTICSEARCH_HOST = "{{theme_elasticsearch_host}}";
+      DOCUMENTATION_OPTIONS.ELASTICSEARCH_INDEX = "{{theme_elasticsearch_index}}";
+      DOCUMENTATION_OPTIONS.PUBLIC_URL_ROOT = "{{theme_public_url_root}}";
+    </script>
+  {% endif %}
 {% endblock %}


### PR DESCRIPTION
> RemovedInSphinx30Warning: To modify script_files in the theme is deprecated. Please insert a <script> tag directly in your theme instead.

Expects current version of **search.html** from [`sphinx_rtd_theme`](https://github.com/readthedocs/sphinx_rtd_theme/blob/master/sphinx_rtd_theme/search.html)!

Ich habe nicht herausgefunden, wie ich die aktuelle Version des `sphinx_rtd_theme` einbinden kann. Lokal habe ich noch eine Version, die `script_files` setzt.